### PR TITLE
Update server latest.json

### DIFF
--- a/server/stable/json/latest.json
+++ b/server/stable/json/latest.json
@@ -12,7 +12,7 @@
     },
     { 
       "type": "Tarball",
-      "version": "10.13.3",
+      "version": "10.13.4",
       "label": ".TAR",
       "url": "https://download.owncloud.com/server/stable/owncloud-complete-20231213.tar.bz2",
       "md5": "https://download.owncloud.com/server/stable/owncloud-complete-20231213.tar.bz2.md5",
@@ -54,7 +54,7 @@
     },
     {
       "type": "Tarball",
-      "version": "10.13.3",
+      "version": "10.13.4",
       "label": ".TAR",
       "url": "https://download.owncloud.com/server/testing/owncloud-complete-20231213-qa.tar.bz2",
       "md5": "https://download.owncloud.com/server/testing/owncloud-complete-20231213-qa.tar.bz2.md5",


### PR DESCRIPTION
a few places still had 10.13.4

(Would be much easier to keep consistent, if a variabe could be used....)